### PR TITLE
chore: add vitepress plugin support metadata

### DIFF
--- a/packages/vitepress-plugin-previews/package.json
+++ b/packages/vitepress-plugin-previews/package.json
@@ -31,7 +31,10 @@
   "keywords": [
     "vitepress"
   ],
-  "bugs": "https://github.com/tapp-ai/open-source/issues",
+  "bugs": {
+    "url": "https://github.com/tapp-ai/open-source/issues"
+  },
+  "homepage": "https://github.com/tapp-ai/open-source/tree/main/packages/vitepress-plugin-previews#readme",
   "license": "MIT",
   "author": "Matthew Rowland (https://github.com/mathhulk/)",
   "repository": {


### PR DESCRIPTION
## Summary
- convert ugs from a string into the standard npm ugs.url object
- add homepage pointing at the package README in this monorepo

## Validation
- parsed packages/vitepress-plugin-previews/package.json as JSON
- confirmed ugs.url and homepage are present
- left runtime code, dependencies, exports, version, license, and repository metadata unchanged